### PR TITLE
Remove unused metrics initialization

### DIFF
--- a/src/main/java/dev/drawethree/xprison/XPrison.java
+++ b/src/main/java/dev/drawethree/xprison/XPrison.java
@@ -127,7 +127,6 @@ public final class XPrison extends ExtendedJavaPlugin {
 
 		this.registerMainEvents();
 		this.registerMainCommand();
-		this.startMetrics();
 
 		SkullUtils.init();
 	}
@@ -275,9 +274,6 @@ public final class XPrison extends ExtendedJavaPlugin {
 		Events.subscribe(PlayerQuitEvent.class, EventPriority.LOW).handler(playerQuitEvent -> PersistentActionBar.stop(playerQuitEvent.getPlayer())).bindWith(this);
 	}
 
-	private void startMetrics() {
-		new Metrics(this, Constants.METRICS_SERVICE_ID);
-	}
 
 	private void loadModule(@NotNull XPrisonModule module) {
 		if (module.isEnabled()) {


### PR DESCRIPTION
The `startMetrics` method and its invocation have been removed as they are no longer in use. This cleans up the codebase and eliminates unnecessary functionality.